### PR TITLE
Add security scan to the CI flow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
-  release:
-    name: Release
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Init
@@ -36,6 +36,28 @@ jobs:
       - name: Test
         run: go test -v $(go list ./... | grep -v vendor | grep -v mocks) -race -coverprofile=coverage.txt -covermode=atomic
 
+  scan:
+    name: Security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -o security-group-manager
 


### PR DESCRIPTION
This PR contains code in order to add a 'Security scan' job for the CI flow. 