### PR TITLE
Add security scan to the 'Release' CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Test
         run: go test -v $(go list ./... | grep -v vendor | grep -v mocks) -race -coverprofile=coverage.txt -covermode=atomic
 
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
       - name: Build
         run: GOOS=linux GOARCH=amd64 go build -o security-group-manager
 


### PR DESCRIPTION
This PR contains code in order to add a security scan to the 'Release' CI.